### PR TITLE
Added per tenant npav-ts-metrics

### DIFF
--- a/dashboards/Spark-1534773680899.json
+++ b/dashboards/Spark-1534773680899.json
@@ -16,7 +16,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": 19,
-  "iteration": 1554744342767,
+  "iteration": 1564407731648,
   "links": [],
   "panels": [
     {
@@ -318,6 +318,14 @@
           "intervalFactor": 1,
           "legendFormat": "storage",
           "refId": "D"
+        },
+        {
+          "expr": "avg_over_time(kafka_server_brokertopicmetrics_oneminuterate{topic=~\"npav-ts-metrics.+\", name=\"MessagesInPerSec\"}[3m])",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "{{topic}}",
+          "refId": "E"
         }
       ],
       "thresholds": [


### PR DESCRIPTION
Added npav-ts-metrics-tenantId> to the spark grafana dashboard.  See 4th line of attached image.

![Screen Shot 2019-07-29 at 3 48 02 PM](https://user-images.githubusercontent.com/52926679/62077534-549c4f00-b218-11e9-9eee-2e252027307b.png)
