### PR TITLE
Change roadrunner dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+* Roadrunner: add connectorId to Roadrunner Connection Status panel legend [Asana](https://app.asana.com/0/1203946223090617/1205293981648408/f)
 ## Current Release 
 ### 0.147.0 
 **Release Date:** Wed Oct 18 10:23:32 UTC 2023     

--- a/dashboards/Roadrunner.json
+++ b/dashboards/Roadrunner.json
@@ -432,7 +432,7 @@
           "expr": "roadrunner_connection",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "{{hostname}}-{{zone}}-{{tenant}}",
+          "legendFormat": "{{hostname}}-{{zone}}-{{connectorId}}-{{tenant}}",
           "refId": "A"
         }
       ],


### PR DESCRIPTION
https://app.asana.com/0/1203946223090617/1205293981648408/f

With the high availability feature the connector id gains importance. A zone may be not enough to identify Roadrunner. That's why metrics get connector id.

I didn't add connector id to all possible legends due to confusion it may lead to. I'm not even sure about the change in _Roadrunner Connection Status_

_Current Roadrunner Status_ changed out of the box (due to change in the metric).

<img width="1330" alt="Screenshot 2023-10-31 at 17 42 46" src="https://github.com/grafana/grafana-docker/assets/17945309/4b5544db-b211-4f0b-ab99-bf81a2ba295e">


_Roadrunner Connection Status_ **before**

<img width="678" alt="Screenshot 2023-10-31 at 17 45 18" src="https://github.com/grafana/grafana-docker/assets/17945309/e48a51fc-4788-4621-a4cc-7fa17949e038">

_Roadrunner Connection Status_ **after**

<img width="678" alt="Screenshot 2023-10-31 at 17 45 38" src="https://github.com/grafana/grafana-docker/assets/17945309/f6f90866-c520-47c0-a42f-9559b7eda7ab">

