### PR TITLE
Install plugins at build time rather than run-time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+Change - Plugins installed at build time and delivered with container rather than downloading each time on startup (Fixes OnPrem/Airgap) [Asana](https://app.asana.com/0/1164034792466845/1207030749728887/f)
 ## Current Release 
 ### 0.155.0 
 **Release Date:** Mon Mar 18 21:09:17 UTC 2024     

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,14 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     && apt-get clean \
     && rm --recursive --force /var/lib/apt/lists/*
 
+RUN mkdir -p /data/grafana/plugins && chown -R grafana:grafana /data/grafana/plugins
+RUN grafana-cli --pluginsDir "/data/grafana/plugins" plugins install xginn8-pagerduty-datasource
+RUN grafana-cli --pluginsDir "/data/grafana/plugins" plugins install grafana-image-renderer 3.7.2
+#TODO  remove grafana-image-renderer version when official fix is implemented for the latest version
+RUN grafana-cli --pluginsDir "/data/grafana/plugins" plugins install grafana-clock-panel
+RUN grafana-cli --pluginsDir "/data/grafana/plugins" plugins install grafana-piechart-panel
+RUN grafana-cli --pluginsDir "/data/grafana/plugins" plugins install grafana-clickhouse-datasource
+
 VOLUME ["/var/lib/grafana", "/var/log/grafana", "/etc/grafana"]
 
 EXPOSE 3000


### PR DESCRIPTION
Changes where we install plugins (build time rather than runtime - which breaks at some onprem and all airgap.
Tested on sre-ops.