### PR TITLE
chore: remove inline Helm install from CI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,12 +29,6 @@ jobs:
           command: make build
 
       - run:
-          name: "install helm"
-          command: |
-            wget -LO helm.tar.gz https://get.helm.sh/helm-v3.17.2-linux-amd64.tar.gz  # legit:ignore-pipeline
-            tar xf helm.tar.gz linux-amd64/helm
-            sudo mv linux-amd64/helm /usr/local/bin
-      - run:
           name: "make chart"
           command: |
             make helm 
@@ -57,12 +51,6 @@ jobs:
             # echo ${DEVHUB_TOKEN} | docker login -u ${DEVHUB_USER} --password-stdin https://artifactory.devhub-cloud.cisco.com
             # make circleci-devhubpush
 
-      - run:
-          name: "install helm"
-          command: |
-            wget -LO helm.tar.gz https://get.helm.sh/helm-v3.17.2-linux-amd64.tar.gz  # legit:ignore-pipeline
-            tar xf helm.tar.gz linux-amd64/helm
-            sudo mv linux-amd64/helm /usr/local/bin
       - run:
           name: "login helm"
           command: |


### PR DESCRIPTION
# Summary of change
- Remove inline Helm binary download from CircleCI config — Helm is now pre-installed on BES runner images

# Code Attribution
- **AI-authored changes:** ~12 lines deleted (~100% of changes) [model: Claude Sonnet 4]
- **Human-authored changes:** ~0 lines (0%)
- **Attribution method:** AI-generated bulk removal of Helm install step across Accedian repos. Human reviewed and approved the automation.

# Detailed description
- **What changed:** Removed the `install helm` run step from `.circleci/config.yml`. This step was downloading Helm v3.17.2 binary from `get.helm.sh` on every CI run.
- **Why:** Helm is now pre-installed on all BES runner images, making the per-job download unnecessary. Removing it:
  - Eliminates an external dependency on `get.helm.sh` during CI
  - Reduces job startup time
  - Removes a potential point of failure if the Helm CDN is unreachable

# Agent pre-validation summary
- Scanned 579 repos in Accedian org; identified 51 repos with Helm install steps
- Removal targets only the `- run:` block with `name: "install helm"` / `name: "Install Helm"`
- No other steps or config sections are modified
- YAML structure validated: surrounding steps remain intact

<details>
<summary>Removed block</summary>

```yaml
      - run:
          name: "install helm"
          command: |
            wget -LO helm.tar.gz https://get.helm.sh/helm-v3.17.2-linux-amd64.tar.gz  # legit:ignore-pipeline
            tar xf helm.tar.gz linux-amd64/helm
            sudo mv linux-amd64/helm /usr/local/bin
      - run:
          name: "install helm"
          command: |
            wget -LO helm.tar.gz https://get.helm.sh/helm-v3.17.2-linux-amd64.tar.gz  # legit:ignore-pipeline
            tar xf helm.tar.gz linux-amd64/helm
            sudo mv linux-amd64/helm /usr/local/bin
```
</details>
