### PR TITLE
SBE - Fix Grafana Stitchit API Call Duration widget

### DIFF
--- a/dashboards/StitchitMetrics.json
+++ b/dashboards/StitchitMetrics.json
@@ -78,7 +78,7 @@
                 }
               ]
             },
-            "unit": "short"
+            "unit": "s"
           },
           "overrides": []
         },
@@ -108,10 +108,10 @@
           {
             "datasource": "Prometheus",
             "editorMode": "code",
-            "expr": "stitchit_api_call_duration",
+            "expr": "(sum(rate(stitchit_stitchit_api_call_duration_sum[$__rate_interval])) by (name)) / (sum(rate(stitchit_stitchit_api_call_duration_count[$__rate_interval])) by (name))",
             "format": "time_series",
             "intervalFactor": 1,
-            "legendFormat": "{{name}}:{{quantile}}",
+            "legendFormat": "{{name}}",
             "range": true,
             "refId": "A"
           }
@@ -173,7 +173,7 @@
                 }
               ]
             },
-            "unit": "short"
+            "unit": "s"
           },
           "overrides": []
         },


### PR DESCRIPTION
### Tasks

[SBE - Fix grafana stitchit API Call Duration widget](https://app.asana.com/1/5557457880942/project/1207589910511516/task/1210823321613482?focus=true)

### Summary

- Update the Stitchit `API Call Duration` panel to visualize average request duration from the provisioned Prometheus summary series.
- Replace the root metric query with `_sum / _count` rate math using `stitchit_stitchit_api_call_duration_sum` and `stitchit_stitchit_api_call_duration_count`.
- Format both Stitchit duration panels as seconds, so `API Call Duration` and `Dgraph Call Duration` use consistent duration units.
- Use the API `name` label for the fixed API duration legend.

Verification:

- Parsed `dashboards/StitchitMetrics.json` as JSON with Node.
- Ran local Grafana 11.5.0 against a mock Prometheus endpoint.
- Captured before screenshot with the old root metric query showing no data.
- Captured after screenshot with the fixed average-duration query showing a rendered time series.

### Media

|Before|After|
|:---:|:---:|
<img width="926" height="415" alt="Screenshot 2026-05-11 at 8 12 17 AM" src="https://github.com/user-attachments/assets/73d9cddf-2f2c-4485-83fa-35b8a0a5abcf" /> | <img width="801" height="295" alt="Screenshot 2026-05-11 at 8 15 40 AM" src="https://github.com/user-attachments/assets/67f95da8-93a2-4600-b8c9-0b7363caeb95" />

### TODO

None.