### PR TITLE
chore: update base images to approved versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM debian:stable-slim
+## runtime : tag: "gcr.io/npav-172917/sto-ccc-cloud9/hardened_debian:12-slim" ##
+FROM gcr.io/npav-172917/sto-ccc-cloud9/hardened_debian@sha256:08a4dbdd271ed3740a5a41ffcf6df118755272c0fec35aef2f61df174700c5c8
 
 ARG TARGETARCH
 ARG GRAFANA_VERSION


### PR DESCRIPTION
## Base Image Version Update

Updated base images to match approved versions in `versions.yaml` (working-tree manifest in image-governance).

### Changes

| File | Type | Name | Before | After |
|------|------|------|--------|-------|
| `Dockerfile` | FROM | direct | `debian:stable-slim` | `gcr.io/npav-172917/sto-ccc-cloud9/hardened_debian@sha256:08a4dbdd271ed3740a5a41ffcf6df118755272c0fec35aef2f61df174700c5c8` |

### Source
- Manifest repo: [Accedian/image-governance](https://github.com/Accedian/image-governance)
- `versions.yaml`: [main/versions.yaml](https://github.com/Accedian/image-governance/blob/main/versions.yaml)
- Generated by: `update-versions.sh`
- GitHub topic: `bes-244343`