### PR TITLE
feat: Add Cerbos Authorization Metrics dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+* Feat - Add Cerbos Authorization Metrics dashboard [Asana](https://app.asana.com/1/5557457880942/project/1212700598162622/task/1211002245600706?focus=true)
 ## Current Release
 ### 0.217.0
 **Release Date:** Wed Jun  3 13:56:26 UTC 2026

--- a/dashboards/CerbosAuthorizationMetrics.json
+++ b/dashboards/CerbosAuthorizationMetrics.json
@@ -1,0 +1,356 @@
+{
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": "Grafana",
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "target": {
+            "limit": 100,
+            "matchAny": false,
+            "tags": [],
+            "type": "dashboard"
+          },
+          "type": "dashboard"
+        }
+      ]
+    },
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "graphTooltip": 0,
+    "id": null,
+    "links": [],
+    "panels": [
+      {
+        "datasource": "Prometheus",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 10,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "reqps"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 10,
+          "w": 12,
+          "x": 0,
+          "y": 0
+        },
+        "id": 1,
+        "options": {
+          "alertThreshold": true,
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "hideZeros": false,
+            "mode": "multi",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "11.5.0",
+        "targets": [
+          {
+            "datasource": "Prometheus",
+            "editorMode": "code",
+            "expr": "sum by (service, method) (rate({__name__=~\"stitchit_cerbos_check_requests_total|gather_cerbos_check_requests_total\", tenant_id=~\"$tenant_id\"}[$__rate_interval]))",
+            "format": "time_series",
+            "intervalFactor": 1,
+            "legendFormat": "{{service}} - {{method}}",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Request Rate by Service",
+        "type": "timeseries"
+      },
+      {
+        "datasource": "Prometheus",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 10,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "normal"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "reqps"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 10,
+          "w": 12,
+          "x": 12,
+          "y": 0
+        },
+        "id": 2,
+        "options": {
+          "alertThreshold": true,
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "hideZeros": false,
+            "mode": "multi",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "11.5.0",
+        "targets": [
+          {
+            "datasource": "Prometheus",
+            "editorMode": "code",
+            "expr": "sum by (service, method, result) (rate({__name__=~\"stitchit_cerbos_check_requests_total|gather_cerbos_check_requests_total\", tenant_id=~\"$tenant_id\"}[$__rate_interval]))",
+            "format": "time_series",
+            "intervalFactor": 1,
+            "legendFormat": "{{service}} - {{method}} - {{result}}",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Results Breakdown",
+        "type": "timeseries"
+      },
+      {
+        "datasource": "Prometheus",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "align": "auto",
+              "cellOptions": {
+                "type": "auto"
+              },
+              "inspect": false
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": [
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "resource"
+              },
+              "properties": [
+                {
+                  "id": "custom.width",
+                  "value": 400
+                }
+              ]
+            }
+          ]
+        },
+        "gridPos": {
+          "h": 10,
+          "w": 24,
+          "x": 0,
+          "y": 10
+        },
+        "id": 3,
+        "options": {
+          "cellHeight": "sm",
+          "footer": {
+            "countRows": false,
+            "fields": "",
+            "reducer": [
+              "sum"
+            ],
+            "show": false
+          },
+          "showHeader": true,
+          "sortBy": [
+            {
+              "desc": true,
+              "displayName": "Value"
+            }
+          ]
+        },
+        "pluginVersion": "11.5.0",
+        "targets": [
+          {
+            "datasource": "Prometheus",
+            "editorMode": "code",
+            "expr": "topk(10, sum by (resource) (increase({__name__=~\"stitchit_cerbos_check_requests_total|gather_cerbos_check_requests_total\", tenant_id=~\"$tenant_id\", result=\"DENY\"}[$__range])))",
+            "format": "table",
+            "instant": true,
+            "intervalFactor": 1,
+            "legendFormat": "",
+            "refId": "A"
+          }
+        ],
+        "title": "Top Denied Resources",
+        "transformations": [
+          {
+            "id": "organize",
+            "options": {
+              "excludeByName": {
+                "Time": true
+              },
+              "renameByName": {
+                "Value": "Deny Count",
+                "resource": "Resource"
+              }
+            }
+          }
+        ],
+        "type": "table"
+      }
+    ],
+    "preload": false,
+    "refresh": "",
+    "schemaVersion": 40,
+    "tags": [],
+    "templating": {
+      "list": [
+        {
+          "allValue": ".*",
+          "current": {},
+          "datasource": "Prometheus",
+          "definition": "label_values({__name__=~\"stitchit_cerbos_check_requests_total|gather_cerbos_check_requests_total\"}, tenant_id)",
+          "hide": 0,
+          "includeAll": true,
+          "label": "Tenant ID",
+          "multi": false,
+          "name": "tenant_id",
+          "options": [],
+          "query": {
+            "qryType": 1,
+            "query": "label_values({__name__=~\"stitchit_cerbos_check_requests_total|gather_cerbos_check_requests_total\"}, tenant_id)"
+          },
+          "refresh": 2,
+          "regex": "",
+          "skipUrlSync": false,
+          "sort": 1,
+          "type": "query"
+        }
+      ]
+    },
+    "time": {
+      "from": "now-30m",
+      "to": "now"
+    },
+    "timepicker": {},
+    "timezone": "",
+    "title": "Cerbos Authorization Metrics",
+    "uid": "cerbos-authz-metrics",
+    "version": 1,
+    "weekStart": ""
+  }


### PR DESCRIPTION
* Feat - Add Grafana dashboard for Cerbos authorization metrics [Asana](https://app.asana.com/1/5557457880942/project/1211068271936376/task/1211002245600706?focus=true)

Dashboard JSON removed from this repo — moved to grafana-docker per review feedback. This PR now contains:

Removed dashboards/CerbosAuthorizationMetrics.json
Removed Grafana Dashboard section from README.md
Admin API reference docs retained in README
CHANGELOG updated noting dashboard moved to grafana-docker

Verified with live data on Replicated:
<img width="468" height="267" alt="image" src="https://github.com/user-attachments/assets/717d72ff-bd2f-4573-970a-c9261d210320" />
<img width="468" height="228" alt="image" src="https://github.com/user-attachments/assets/1beed159-25ea-41dd-82bd-c7d39ae17eeb" />

StitchIt pr: https://github.com/Accedian/stitchIt/pull/182
Gather pr: https://github.com/Accedian/adh-gather/pull/2435
Grafana: https://github.com/Accedian/grafana-docker/tree/feature/cerbos-authorization-metrics

Once the grafana-docker branch is merged and a new Grafana image is built, the dashboard is automatically available on all new deployments.

Images:
Grafana: `gcr.io/npav-172917/grafana:0.208.0-cerbos-dashboard`
StitchIt: `gcr.io/npav-172917/stitchit:0.116.0-cerbos-metrics`
Gather: `gcr.io/npav-172917/adh-gather:0.1674.0-cerbos-metrics`
skylight-analytics-app: https://github.com/Accedian/skylight-analytics-app/pull/145

Dashbord available at: 
`https://<your-pca-hostname>/grafana/d/cerbos-authz-metrics/cerbos-authorization-metrics`