### PR TITLE
chore: update base images to approved versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Base image updates - 2026-06-12
+
+### Changed
+- Update base images to approved versions:
+  - Bump image in `Dockerfile`: `debian:stable-slim` → `gcr.io/npav-172917/sto-ccc-cloud9/hardened_debian@sha256:08a4dbdd271ed3740a5a41ffcf6df118755272c0fec35aef2f61df174700c5c8`
+
 ## Current Release
 ### 0.219.0
 **Release Date:** Fri Jun 12 13:09:44 UTC 2026

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM debian:stable-slim
+## runtime : tag: "gcr.io/npav-172917/sto-ccc-cloud9/hardened_debian:12-slim" ##
+FROM gcr.io/npav-172917/sto-ccc-cloud9/hardened_debian@sha256:08a4dbdd271ed3740a5a41ffcf6df118755272c0fec35aef2f61df174700c5c8
 
 ARG TARGETARCH
 ARG GRAFANA_VERSION


### PR DESCRIPTION
## Base Image Version Update

Updated base images to match approved versions in `versions.yaml` (working-tree manifest in image-governance).

### Changes

| File | Type | Name | Before | After |
|------|------|------|--------|-------|
| `Dockerfile` | FROM | direct | `debian:stable-slim` | `gcr.io/npav-172917/sto-ccc-cloud9/hardened_debian@sha256:08a4dbdd271ed3740a5a41ffcf6df118755272c0fec35aef2f61df174700c5c8` |

### Source
- Manifest repo: [Accedian/image-governance](https://github.com/Accedian/image-governance)
- `versions.yaml`: [main/versions.yaml](https://github.com/Accedian/image-governance/blob/main/versions.yaml)
- Generated by: `update-versions.sh`
- GitHub topic: `bes-244343`
- Changelog updated: `CHANGELOG.md`

_Commit is S/MIME (X.509) signed._